### PR TITLE
WARNING: Unknown command-line argument "--rms-mode"

### DIFF
--- a/DynamicAudioNormalizerCLI/src/Main.cpp
+++ b/DynamicAudioNormalizerCLI/src/Main.cpp
@@ -358,7 +358,7 @@ static void printHelpScreen(int argc, CHR* argv[])
 	PRINT(TXT("  -g --gauss-size <value>  Gauss filter size, in frames [default: %u]\n"),     defaults.filterSize());
 	PRINT(TXT("  -p --peak <value>        Target peak magnitude, 0.1-1 [default: %.2f]\n"),   defaults.peakValue());
 	PRINT(TXT("  -m --max-gain <value>    Maximum gain factor [default: %.2f]\n"),            defaults.maxAmplification());
-	PRINT(TXT("  -r --rms-mode <value>    Target RMS value [default: %.2f]\n"),               defaults.targetRms());
+	PRINT(TXT("  -r --target-rms <value>    Target RMS value [default: %.2f]\n"),             defaults.targetRms());
 	PRINT(TXT("  -n --no-coupling         Disable channel coupling [default: %s]\n"),         BOOLIFY(defaults.channelsCoupled()));
 	PRINT(TXT("  -c --correct-dc          Enable the DC bias correction [default: %s]\n"),    BOOLIFY(defaults.enableDCCorrection()));
 	PRINT(TXT("  -b --alt-boundary        Use alternative boundary mode [default: %s]\n"),    BOOLIFY(defaults.altBoundaryMode()));


### PR DESCRIPTION
hi,

Just compiled it from git (Linux) and got:

`WARNING: Unknown command-line argument "--rms-mode"`

You seem to be using in your tests: [--target-rms](https://github.com/lordmulder/DynamicAudioNormalizer/blob/dfc790ac0c33e96177fba4aa9d418fa844f5599d/z_test.bat#L13)

Also your dos refer to it: [RMS processing can be enabled using the --target-rms switch.](http://muldersoft.com/docs/dyauno_readme.html#target-rms-value)

BTW: nice app  :+1: